### PR TITLE
define m2e lifecycle-mappings to allow easy eclipse integration

### DIFF
--- a/access-modifier-checker/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/access-modifier-checker/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,14 @@
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>enforce</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
by defining the m2e lifecycle-mappings for eclipse, a project using this plugin and imported into eclipse will not show an error message.
please also see: http://wiki.eclipse.org/M2E_compatible_maven_plugins

as soon as this is integrated, the parent jenkins pom for plugins should be updated to use this version.
