### PR TITLE
Update `annotation-indexer` library to 1.14

### DIFF
--- a/access-modifier-annotation/pom.xml
+++ b/access-modifier-annotation/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
+      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -132,7 +132,7 @@ public class Checker {
      * Loads all the access restrictions defined in our dependencies.
      */
     private void loadAccessRestrictions() throws IOException {
-        final Enumeration<URL> res = dependencies.getResources("META-INF/annotations/"+Restricted.class.getName());
+        final Enumeration<URL> res = dependencies.getResources("META-INF/services/annotations/"+Restricted.class.getName());
         while (res.hasMoreElements()) {
             URL url = res.nextElement();
             loadRestrictions(url.openStream(),false);
@@ -140,7 +140,7 @@ public class Checker {
     }
 
     /**
-     * Loads an additional restriction from the specified "META-INF/annotations/org.kohsuke.accmod.Restricted" file.
+     * Loads an additional restriction from the specified "META-INF/services/annotations/org.kohsuke.accmod.Restricted" file.
      *
      * @param isInTheInspectedModule
      *      This value shows up in {@link RestrictedElement#isInTheInspectedModule()}.

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
@@ -96,7 +96,7 @@ public class EnforcerMojo extends AbstractMojo {
             {// if there's restriction list in the inspected module itself, load it as well
                 InputStream self = null;
                 try {
-                    self = new URL(outputURL, "META-INF/annotations/" + Restricted.class.getName()).openStream();
+                    self = new URL(outputURL, "META-INF/services/annotations/" + Restricted.class.getName()).openStream();
                 } catch (IOException e) {
                 }
                 if (self!=null)


### PR DESCRIPTION
Just like https://github.com/infradna/bridge-method-injector/pull/25, we need to adapt to https://github.com/jenkinsci/lib-annotation-indexer/pull/10. Otherwise the checker does not work at all, it seems.
