### PR TITLE
[JENKINS-66247] Call `Index.listClassNames`

### DIFF
--- a/access-modifier-annotation/pom.xml
+++ b/access-modifier-annotation/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.15-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/lib-annotation-indexer/pull/12 -->
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/access-modifier-annotation/pom.xml
+++ b/access-modifier-annotation/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.14</version>
+      <version>1.15-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/lib-annotation-indexer/pull/12 -->
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -39,20 +39,17 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.jvnet.hudson.annotation_indexer.Index;
 
 import static org.objectweb.asm.ClassReader.SKIP_FRAMES;
 
@@ -132,11 +129,7 @@ public class Checker {
      * Loads all the access restrictions defined in our dependencies.
      */
     private void loadAccessRestrictions() throws IOException {
-        final Enumeration<URL> res = dependencies.getResources("META-INF/services/annotations/"+Restricted.class.getName());
-        while (res.hasMoreElements()) {
-            URL url = res.nextElement();
-            loadRestrictions(url.openStream(),false);
-        }
+        loadRestrictions(dependencies, false);
     }
 
     /**
@@ -144,14 +137,9 @@ public class Checker {
      *
      * @param isInTheInspectedModule
      *      This value shows up in {@link RestrictedElement#isInTheInspectedModule()}.
-     * @param stream
      */
-    public void loadRestrictions(InputStream stream, final boolean isInTheInspectedModule) throws IOException {
-        if (stream==null)      return;
-
-        BufferedReader r = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
-        String className;
-        while ((className=r.readLine())!=null) {
+    public void loadRestrictions(ClassLoader cl, final boolean isInTheInspectedModule) throws IOException {
+        for (String className : Index.listClassNames(Restricted.class, cl)) {
             InputStream is = dependencies.getResourceAsStream(className.replace('.','/') + ".class");
             if (is==null) {
                 errorListener.onWarning(null,null,"Failed to find class file for "+ className);

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -23,7 +23,6 @@
  */
 package org.kohsuke.accmod.impl;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.maven.plugin.logging.Log;

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
@@ -14,7 +14,6 @@ import org.kohsuke.accmod.Restricted;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -94,13 +93,10 @@ public class EnforcerMojo extends AbstractMojo {
                 }, properties != null ? properties : new Properties(), getLog());
 
             {// if there's restriction list in the inspected module itself, load it as well
-                InputStream self = null;
                 try {
-                    self = new URL(outputURL, "META-INF/services/annotations/" + Restricted.class.getName()).openStream();
+                    checker.loadRestrictions(new URLClassLoader(new URL[] {outputURL}, ClassLoader.getSystemClassLoader().getParent()), true);
                 } catch (IOException e) {
                 }
-                if (self!=null)
-                    checker.loadRestrictions(self, true);
             }
 
             // perform checks


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/lib-annotation-indexer/pull/12. Amends #50. Unfortunately we cannot use this in `plugin-pom` any time soon because the version of `access-modifier-checker` must remain somehow compatible (not throw exceptions) when working with an older version of `annotation-indexer` present in core. Thus we cannot upgrade the checker until the minimum core version (some LTS) includes the dependency bump.