### PR TITLE
`@SuppressRestrictedWarnings` did not need `RUNTIME` retention

### DIFF
--- a/access-modifier-suppressions/src/main/java/org/kohsuke/accmod/restrictions/suppressions/SuppressRestrictedWarnings.java
+++ b/access-modifier-suppressions/src/main/java/org/kohsuke/accmod/restrictions/suppressions/SuppressRestrictedWarnings.java
@@ -26,10 +26,9 @@ package org.kohsuke.accmod.restrictions.suppressions;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.kohsuke.accmod.Restricted;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * <p>Indicates that certain classes annotated with {@link Restricted} annotations should be skipped during the
@@ -40,7 +39,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Arch
  */
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Documented
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
 public @interface SuppressRestrictedWarnings {


### PR DESCRIPTION
Seems to have been a contributing cause of a Guice error encountered by @schottsfired when an `optional` dependency was not present in the test classpath:

```
java.lang.ArrayStoreException: sun.reflect.annotation.TypeNotPresentExceptionProxy
        at sun.reflect.annotation.AnnotationParser.parseClassArray(AnnotationParser.java:724)
        at sun.reflect.annotation.AnnotationParser.parseArray(AnnotationParser.java:531)
        at sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:355)
        at sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:286)
        at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
        at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
        at java.lang.Class.createAnnotationData(Class.java:3521)
        at java.lang.Class.annotationData(Class.java:3510)
        at java.lang.Class.getAnnotation(Class.java:3415)
        at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:629)
        at com.google.inject.internal.UntargettedBindingProcessor$1.visit(UntargettedBindingProcessor.java:51)
        at com.google.inject.internal.UntargettedBindingProcessor$1.visit(UntargettedBindingProcessor.java:35)
        at com.google.inject.internal.UntargettedBindingImpl.acceptTargetVisitor(UntargettedBindingImpl.java:41)
        at com.google.inject.internal.UntargettedBindingProcessor.visit(UntargettedBindingProcessor.java:35)
        at com.google.inject.internal.UntargettedBindingProcessor.visit(UntargettedBindingProcessor.java:27)
        at com.google.inject.internal.BindingImpl.acceptVisitor(BindingImpl.java:93)
        at com.google.inject.internal.AbstractProcessor.process(AbstractProcessor.java:56)
        at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:187)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
        at com.google.inject.Guice.createInjector(Guice.java:96)
        at com.google.inject.Guice.createInjector(Guice.java:73)
        at hudson.ExtensionFinder$GuiceFinder.<init>(ExtensionFinder.java:281)
        at …
```

Note that neither the annotation nor the annotated member are shown in the stack trace; that seems similar to (but distinct from) an error better diagnosed in https://github.com/google/guice/pull/1279.

Amends #16.