### PR TITLE
set maven libs according to consumers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
+      - dependency-name: "org.apache.maven:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/access-modifier-checker/pom.xml
+++ b/access-modifier-checker/pom.xml
@@ -78,7 +78,7 @@
               <rules>
                 <requireUpperBoundDeps>
                   <excludes combine.children="append">
-                    <exclude>org.apache.commons:commons-lang3</exclude>
+                    <exclude>org.slf4j:slf4j-api</exclude>
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>

--- a/access-modifier-checker/pom.xml
+++ b/access-modifier-checker/pom.xml
@@ -11,8 +11,12 @@
   <name>Custom Access Modifier Checker</name>
 
   <properties>
-    <maven.version>3.9.0</maven.version>
+    <maven.version>3.8.1</maven.version>
   </properties>
+
+  <prerequisites>
+      <maven>${maven.version}</maven>
+  </prerequisites>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
use a version of maven libs that we expect to be satisfied by consumers.

cf https://github.com/jenkinsci/maven-hpi-plugin/pull/440#issuecomment-1454825697

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
