### PR TITLE
Stop pinning `plexus-utils`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     ignore:
       # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
       - dependency-name: "org.apache.maven:*"
-      # https://lists.apache.org/thread/ltd1g1dbv0lqqdw5q941gmrkfyn6m87m
-      - dependency-name: "org.codehaus.plexus:plexus-utils"
-        versions: [">=4.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.5.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>9.7</version>


### PR DESCRIPTION
Maven 3: `plexus-utils` 4 and `plexus-xml` 3
Maven 4: `plexus-utils` 4 and `plexus-xml` 4